### PR TITLE
Fix eager loading

### DIFF
--- a/lib/golden_fleece/context/getters.rb
+++ b/lib/golden_fleece/context/getters.rb
@@ -7,7 +7,7 @@ module GoldenFleece
           # ...and each top-level schema of each attribute...
           schemas[attribute.to_sym].each do |schema_name, schema|
             # ...if there isn't already an instance method named after the schema...
-            if !model_class.new.respond_to?(schema_name)
+            if !model_class.method_defined?(schema_name)
               # ...define a getter for that schema's value!
               model_class.class_eval do
                 define_method schema_name do


### PR DESCRIPTION
Instantiating `model_class` creates an unnecessary DB connection. This causes any model that uses `define_getters` to make a DB call.

AFAIK `.new.respond_to?` is equivalent to `method_defined?`, so this is a minimal change.